### PR TITLE
Read pipeTransport from launch.json when debugging

### DIFF
--- a/src/coreclrDebug/activate.ts
+++ b/src/coreclrDebug/activate.ts
@@ -285,13 +285,20 @@ export class DebugAdapterExecutableFactory implements vscode.DebugAdapterDescrip
         // use the executable specified in the package.json if it exists or determine it based on some other information (e.g. the session)
         if (!executable) {
             const dotNetInfo = await getDotnetInfo(omnisharpOptions.dotNetCliPaths);
-
-            const command = path.join(
-                common.getExtensionPath(),
-                '.debugger',
-                'netcoredbg',
-                'netcoredbg' + CoreClrDebugUtil.getPlatformExeExtension()
-            );
+            const pipeTransport = _session.configuration.pipeTransport;
+            let command = '';
+            let args = ['--interpreter=vscode'];
+            if (typeof pipeTransport === 'object') {
+                command = pipeTransport.debuggerPath;
+                args = pipeTransport.pipeArgs;
+            } else {
+                command = path.join(
+                    common.getExtensionPath(),
+                    '.debugger',
+                    'netcoredbg',
+                    'netcoredbg' + CoreClrDebugUtil.getPlatformExeExtension()
+                );
+            }
 
             // Look to see if DOTNET_ROOT is set, then use dotnet cli path
             const dotnetRoot: string =
@@ -306,7 +313,7 @@ export class DebugAdapterExecutableFactory implements vscode.DebugAdapterDescrip
                 };
             }
 
-            executable = new vscode.DebugAdapterExecutable(command, ['--interpreter=vscode'], options);
+            executable = new vscode.DebugAdapterExecutable(command, args, options);
         }
 
         // make VS Code launch the DA executable


### PR DESCRIPTION
Read the pipeTransport object from launch.json when launching the debugger.
This enables the user to launch the debugger in a much more flexible way.

Example `launch.json` entry
```json
{
    "version": "0.2.0",
    "configurations": [
      {
        "name": "🕹 Debug Game",
        "type": "coreclr",
        "request": "launch",
        "preLaunchTask": "build",
        "program": "",
        "cwd": "${workspaceFolder}",
        "internalConsoleOptions": "openOnSessionStart",
        "pipeTransport": {
            "pipeCwd": "${workspaceFolder}",
            "pipeProgram": "bash",
            "pipeArgs": [
              "-c",
              "${debuggerCommand}",
              "--",
              "/usr/bin/godot"
            ],
            "debuggerPath": "/opt/netcoredbg/netcoredbg",
            "quoteArgs": true
        }
      }
   ]
}