### PR TITLE
Update pipeTransport options to be more robust

### DIFF
--- a/package.json
+++ b/package.json
@@ -2306,9 +2306,6 @@
               "pipeTransport": {
                 "description": "%generateOptionsSchema.pipeTransport.description%",
                 "type": "object",
-                "required": [
-                  "debuggerPath"
-                ],
                 "default": {
                   "pipeCwd": "${workspaceFolder}",
                   "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
@@ -2838,9 +2835,6 @@
               "pipeTransport": {
                 "description": "%generateOptionsSchema.pipeTransport.description%",
                 "type": "object",
-                "required": [
-                  "debuggerPath"
-                ],
                 "default": {
                   "pipeCwd": "${workspaceFolder}",
                   "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
@@ -3646,9 +3640,6 @@
               "pipeTransport": {
                 "description": "%generateOptionsSchema.pipeTransport.description%",
                 "type": "object",
-                "required": [
-                  "debuggerPath"
-                ],
                 "default": {
                   "pipeCwd": "${workspaceFolder}",
                   "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",
@@ -4178,9 +4169,6 @@
               "pipeTransport": {
                 "description": "%generateOptionsSchema.pipeTransport.description%",
                 "type": "object",
-                "required": [
-                  "debuggerPath"
-                ],
                 "default": {
                   "pipeCwd": "${workspaceFolder}",
                   "pipeProgram": "enter the fully qualified path for the pipe program name, for example '/usr/bin/ssh'",

--- a/src/coreclrDebug/activate.ts
+++ b/src/coreclrDebug/activate.ts
@@ -314,6 +314,8 @@ export class DebugAdapterExecutableFactory implements vscode.DebugAdapterDescrip
                 }
                 if (pipeTransport.debuggerArgs) {
                     args = pipeTransport.debuggerArgs;
+                } else {
+                    args.push('--interpreter=vscode', '--');
                 }
                 if (pipeTransport.pipeProgram) {
                     args.push(pipeTransport.pipeProgram);

--- a/src/coreclrDebug/activate.ts
+++ b/src/coreclrDebug/activate.ts
@@ -283,14 +283,47 @@ export class DebugAdapterExecutableFactory implements vscode.DebugAdapterDescrip
         // debugger has finished installation, kick off our debugger process
 
         // use the executable specified in the package.json if it exists or determine it based on some other information (e.g. the session)
-        if (!executable) {
+        const pipeTransport = _session.configuration.pipeTransport;
+        if (!executable || typeof pipeTransport === 'object') {
+            // Look to see if DOTNET_ROOT is set, then use dotnet cli path
             const dotNetInfo = await getDotnetInfo(omnisharpOptions.dotNetCliPaths);
-            const pipeTransport = _session.configuration.pipeTransport;
+            const dotnetRoot: string =
+                process.env.DOTNET_ROOT ?? (dotNetInfo.CliPath ? path.dirname(dotNetInfo.CliPath) : '');
+
+            let options: vscode.DebugAdapterExecutableOptions = {};
+            if (dotnetRoot) {
+                options = {
+                    env: {
+                        DOTNET_ROOT: dotnetRoot,
+                    },
+                };
+            }
+
             let command = '';
-            let args = ['--interpreter=vscode'];
+            let args = [];
             if (typeof pipeTransport === 'object') {
-                command = pipeTransport.debuggerPath;
-                args = pipeTransport.pipeArgs;
+                if (pipeTransport.debuggerPath) {
+                    command = pipeTransport.debuggerPath;
+                } else {
+                    command = path.join(
+                        common.getExtensionPath(),
+                        '.debugger',
+                        'netcoredbg',
+                        'netcoredbg' + CoreClrDebugUtil.getPlatformExeExtension()
+                    );
+                }
+                if (pipeTransport.debuggerArgs) {
+                    args = pipeTransport.debuggerArgs;
+                }
+                if (pipeTransport.pipeProgram) {
+                    args.push(pipeTransport.pipeProgram);
+                }
+                if (pipeTransport.pipeArgs) {
+                    args.push(pipeTransport.pipeArgs);
+                }
+                if (pipeTransport.pipeCwd) {
+                    options.cwd = pipeTransport.pipeCwd;
+                }
             } else {
                 command = path.join(
                     common.getExtensionPath(),
@@ -298,19 +331,7 @@ export class DebugAdapterExecutableFactory implements vscode.DebugAdapterDescrip
                     'netcoredbg',
                     'netcoredbg' + CoreClrDebugUtil.getPlatformExeExtension()
                 );
-            }
-
-            // Look to see if DOTNET_ROOT is set, then use dotnet cli path
-            const dotnetRoot: string =
-                process.env.DOTNET_ROOT ?? (dotNetInfo.CliPath ? path.dirname(dotNetInfo.CliPath) : '');
-
-            let options: vscode.DebugAdapterExecutableOptions | undefined = undefined;
-            if (dotnetRoot) {
-                options = {
-                    env: {
-                        DOTNET_ROOT: dotnetRoot,
-                    },
-                };
+                args = ['--interpreter=vscode'];
             }
 
             executable = new vscode.DebugAdapterExecutable(command, args, options);


### PR DESCRIPTION
This update builds on https://github.com/muhammadsammy/free-vscode-csharp/pull/68 and lets the user launch the default debugger instead of needing to specify where exactly it is.

Also separates command line arguments for the debugger and the launched executable, allowing you to pass additional parameters. Example configuration:
This will launch the debugger as `/var/home/granitrocky/.vscode-oss/extensions/muhammad-sammy.csharp-2.31.19/.debugger/netcoredbg/netcoredbg --interpreter=vscode -- /usr/bin/godot -e`
```json
{
        "name": "🕹 Debug Game",
        "type": "coreclr",
        "request": "launch",
        "preLaunchTask": "build",
        "program": "",
        "cwd": "${workspaceFolder}",
        "internalConsoleOptions": "openOnSessionStart",
        "pipeTransport": {
            "pipeCwd": "${workspaceFolder}",
            "pipeProgram": "/usr/bin/godot",
            "pipeArgs": [
              "-e"
            ]
        }
      }
```

And an example WITH a specific debugger:
THIS will launch the debugger as `/opt/netcoredbg/netcoredbg --interpreter=vscode -- /usr/bin/godot -e`
```json
{
        "name": "🕹 Debug Game",
        "type": "coreclr",
        "request": "launch",
        "preLaunchTask": "build",
        "program": "",
        "cwd": "${workspaceFolder}",
        "internalConsoleOptions": "openOnSessionStart",
        "pipeTransport": {
            "pipeCwd": "${workspaceFolder}",
            "pipeProgram": "/usr/bin/godot",
            "pipeArgs": [
              "-e"
            ],
            "depuggerPath": "/opt/netcoredbg/netcoredbg",
            "debuggerArgs": [
              "--interpreter=vscode",
              "--",
            ],
            "quoteArgs": true
        }
      }
```