### PR TITLE
Fix pipeTransport pipeArgs not being expanded

### DIFF
--- a/src/coreclrDebug/activate.ts
+++ b/src/coreclrDebug/activate.ts
@@ -325,7 +325,7 @@ export class DebugAdapterExecutableFactory implements vscode.DebugAdapterDescrip
                     args.push(pipeTransport.pipeProgram);
                 }
                 if (pipeTransport.pipeArgs) {
-                    args.push(pipeTransport.pipeArgs);
+                    args.push(...pipeTransport.pipeArgs);
                 }
                 if (pipeTransport.pipeCwd) {
                     options.cwd = pipeTransport.pipeCwd;


### PR DESCRIPTION
There's an issue with #72 where the pipeArgs from pipeTransport aren't expanded which is preventing any more than one argument from being used inside a pipeArgs array. The current behavior seems to be if more than one argument is present inside pipeArgs then none of them get used. One argument inside pipeArgs works though.

This is a small fix so that multiple arguments work.