### PR TITLE
Fix undefined _channel variable

### DIFF
--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -1060,7 +1060,7 @@ export async function activateRoslynLanguageServer(
     context: vscode.ExtensionContext,
     platformInfo: PlatformInformation,
     optionObservable: Observable<void>,
-    outputChannel: vscode.OutputChannel,
+    outputChannel: vscode.LogOutputChannel,
     languageServerEvents: RoslynLanguageServerEvents
 ): Promise<RoslynLanguageServer> {
     // Create a channel for outputting general logs from the language server.

--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -1064,7 +1064,7 @@ export async function activateRoslynLanguageServer(
     languageServerEvents: RoslynLanguageServerEvents
 ): Promise<RoslynLanguageServer> {
     // Create a channel for outputting general logs from the language server.
-    // _channel = outputChannel;
+    _channel = outputChannel;
     // Create a separate channel for outputting trace logs - these are incredibly verbose and make other logs very difficult to see.
     // The trace channel verbosity is controlled by the _channel verbosity.
     _traceChannel = vscode.window.createOutputChannel(vscode.l10n.t('C# LSP Trace Logs'));


### PR DESCRIPTION
Starting from `2.55.28` extension not working for me because of undefined `_channel` variable
![screenshot](https://github.com/user-attachments/assets/97b1db18-247a-4686-8186-bbbe476db157)

fix tested with:
![sysinfo](https://github.com/user-attachments/assets/3b5b156a-b909-4fac-a282-5a11ced7a208)

