### PR TITLE
Fix: Could not find extension target platform

### DIFF
--- a/src/lsptoolshost/dotnetRuntimeExtensionResolver.ts
+++ b/src/lsptoolshost/dotnetRuntimeExtensionResolver.ts
@@ -153,7 +153,7 @@ export class DotnetRuntimeExtensionResolver implements IHostExecutableResolver {
         const contents = await readFile(vsixManifestFile, 'utf-8');
         const targetPlatformMatch = /TargetPlatform="(.*)"/.exec(contents);
         if (!targetPlatformMatch) {
-            throw new Error(`Could not find extension target platform in ${vsixManifestFile}`);
+            return undefined;
         }
 
         const targetPlatform = targetPlatformMatch[1];


### PR DESCRIPTION
Latest version of extension will throw error shown below, if package published with:
```
npx gulp 'vsix:release:neutral'
```
![screenshot](https://github.com/user-attachments/assets/e58b4802-816d-4a30-a1bc-f514badf8d40)

Reason is that neutral build doesn't contains `TargetPlatform` in vsixmanifest, which is required here:
https://github.com/muhammadsammy/free-vscode-csharp/blob/2dea855da72425a30f79682c9440de0a77dd0bf3/src/lsptoolshost/dotnetRuntimeExtensionResolver.ts#L153-L157

Suggested solution is to return undefined instead of throwing error, in that case `proccess.arch` will be used:
https://github.com/muhammadsammy/free-vscode-csharp/blob/2dea855da72425a30f79682c9440de0a77dd0bf3/src/lsptoolshost/dotnetRuntimeExtensionResolver.ts#L44

Tested on: VSCodium 1.96.4, windows 11
